### PR TITLE
Configure project for local development

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ OMEJDN_PROTOCOL="https"
 OMEJDN_VERSION="1.7.0"
 
 # Your domain (e.g. sso.example.org)
-OMEJDN_DOMAIN="__HOST__"
+OMEJDN_DOMAIN="localhost"
 
 # The path to mount Omejdn at.
 # This should start but not end with '/'.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "80:80"   # Exposes HTTP on port 80
       - "443:443" # Exposes HTTPS on port 443
     environment:
-      - OMEJDN_DOMAIN=__HOST__
+      - OMEJDN_DOMAIN=localhost
       - OMEJDN_PATH=/auth
       - UI_PATH=/
     volumes:
@@ -37,11 +37,11 @@ services:
       - ELASTICSEARCH_HOSTNAME=broker-elasticsearch
       - SHACL_VALIDATION=true
       - DAPS_VALIDATE_INCOMING=true
-      - COMPONENT_URI=https://__HOST__/broker/
-      - COMPONENT_CATALOGURI=https://__HOST__/broker/connectors/
-      - JWKS_TRUSTEDHOSTS=__HOST__,daps
-      - DAPS_URL=https://__HOST__/auth
-      - DAPS_JWKS_URL=https://__HOST__/auth/jwks.json
+      - COMPONENT_URI=https://localhost/broker/
+      - COMPONENT_CATALOGURI=https://localhost/broker/connectors/
+      - JWKS_TRUSTEDHOSTS=localhost,daps
+      - DAPS_URL=https://localhost/auth
+      - DAPS_JWKS_URL=https://localhost/auth/jwks.json
     expose:
       - "8080" # Internal communication on port 8080
     networks:
@@ -64,8 +64,8 @@ services:
     hostname: daps
     restart: unless-stopped
     environment:
-      - OMEJDN_ISSUER=https://__HOST__/auth
-      - OMEJDN_FRONT_URL=https://__HOST__/auth
+      - OMEJDN_ISSUER=https://localhost/auth
+      - OMEJDN_FRONT_URL=https://localhost/auth
       - OMEJDN_OPENID=true
       - OMEJDN_ENVIRONMENT=${OMEJDN_ENVIRONMENT}
       - OMEJDN_ACCEPT_AUDIENCE=idsc:IDS_CONNECTORS_ALL
@@ -83,8 +83,8 @@ services:
     image: ghcr.io/fraunhofer-aisec/omejdn-ui:${UI_VERSION}
     restart: unless-stopped
     environment:
-      - OIDC_ISSUER=https://__HOST__/auth/
-      - API_URL=https://__HOST__/auth/api/v1
+      - OIDC_ISSUER=https://localhost/auth/
+      - API_URL=https://localhost/auth/api/v1
       - CLIENT_ID=adminUI
     networks:
       - local
@@ -113,9 +113,9 @@ services:
     environment:
       - CONFIGURATION_PATH=/config/config.json
       - SERVER_PORT=8081
-      - DAPS_URL=https://__HOST__/auth
-      - DAPS_TOKEN_URL=https://__HOST__/auth/token
-      - DAPS_KEY_URL=https://__HOST__/auth/jwks.json
+      - DAPS_URL=https://localhost/auth
+      - DAPS_TOKEN_URL=https://localhost/auth/token
+      - DAPS_KEY_URL=https://localhost/auth/jwks.json
       - DAPS_INCOMING_DAT_DEFAULT_WELLKNOWN=/jwks.json
       - SERVER_SSLv_KEY-STORE=file:///conf/default-connector-keystore.p12
       - SPRING_DATASOURCE_URL=jdbc:postgresql://connector-database:5432/connectorbdb
@@ -165,7 +165,7 @@ services:
       - DJANGO_DB_NAME=db.sqlite3
       - DJANGO_LANGUAGE_CODE=en-us
       - DJANGO_TIME_ZONE=UTC
-      - BASE_URL=https://__HOST__/connector-registration/register-connector
+      - BASE_URL=https://localhost/connector-registration/register-connector
     networks:
       - local
 

--- a/nginx.development.conf
+++ b/nginx.development.conf
@@ -11,9 +11,9 @@ http {
     # HTTPS server
     server {
         listen 443 ssl;
-        server_name __HOST__;
-        ssl_certificate /etc/cert/__CERT__;
-        ssl_certificate_key /etc/cert/__KEY__;
+        server_name localhost;
+        ssl_certificate /etc/cert/server.crt;
+        ssl_certificate_key /etc/cert/server.key;
 
         location /connector-registration-user-interface/ {
             rewrite ^/connector-registration-user-interface/(.*)$ /$1 break;
@@ -218,7 +218,7 @@ http {
     # HTTP to HTTPS redirection
     server {
         listen 80;
-        server_name __HOST__;
+        server_name localhost;
 
         # Redirect all HTTP traffic to HTTPS
         location / {


### PR DESCRIPTION
Replace placeholder values (__HOST__, __CERT__, __KEY__) with localhost and actual certificate paths to enable running the project on a laptop.

Changes:
- Update nginx.development.conf to use server.crt/server.key
- Set OMEJDN_DOMAIN to localhost in .env
- Replace all __HOST__ references with localhost in docker-compose.yml

This fixes the nginx container startup failure and allows the project to run locally without requiring a production FQDN and custom certificates.